### PR TITLE
Added support for AWS ElasticBeankstalk Notifications.

### DIFF
--- a/aws-codepipeline-msteams-notification.py
+++ b/aws-codepipeline-msteams-notification.py
@@ -2,6 +2,7 @@
 # Original Author: https://github.com/globaldatanet/aws-codepipeline-notification
 # Modified by: Seff Parker
 # Modified Version: 1.0.3 20210612
+# Modified the payload json check to add support for Elastic Beanstalk
 
 import json
 import logging
@@ -30,10 +31,21 @@ def lambda_handler(event, context):
     awsRegion = message['region']
     stage = message['detail']['stage']
     state = message['detail']['state']
-    if 'external-execution-summary' in message['detail']['execution-result']:
-        summary =  message['detail']['execution-result']['external-execution-summary']
+    if 'execution-result' in message['detail']:
+        if 'external-execution-summary' in message['detail']['execution-result']:
+            summary = message['detail']['execution-result']['external-execution-summary']
+            if 'ProviderType' in summary and 'CommitMessage' in summary:
+                summary = summary['ProviderType'] + "-->" + summary['CommitMessage']
+        else:
+            summary = "Nil"
+    elif 'stage' in message['detail'] and 'action' in message['detail']:
+        action = message['detail']['action']
+        stage = message['detail']['stage']
+        state = message['detail']['state']
+        summary = f" {action} {state} in {stage}"
     else:
         summary = "Nil"
+        
     provider = message['detail']['type']['provider']
     
     # set the color depending on state
@@ -43,17 +55,21 @@ def lambda_handler(event, context):
         color = "#ff0000"
     else:
          color = "#000000"
-		
+        
     # data for message cards
     title = "CodePipeline: " + pipeline    
     accountString = "Account"
     summaryString = "Summary"
     statusString = "Status"
-    if 'external-execution-url' in message['detail']['execution-result']:
-        pipelineURL =  message['detail']['execution-result']['external-execution-url']
-    else:
-        pipelineURL = f"https://{awsRegion}.console.aws.amazon.com/codesuite/codepipeline/pipelines/{pipeline}/view?region={awsRegion}"
     
+    if 'execution-result' in message['detail']:
+        if 'external-execution-url' in message['detail']['execution-result']:
+            pipelineURL =  message['detail']['execution-result']['external-execution-url']
+        else:
+            pipelineURL = f"https://{awsRegion}.console.aws.amazon.com/codesuite/codepipeline/pipelines/{pipeline}/view?region={awsRegion}"
+    else:
+        pipelineURL = "N/A"
+        
     # MS Teams data
     MSTeams = {
         "title": "%s" % title,
@@ -82,8 +98,9 @@ def lambda_handler(event, context):
                 "sections": MSTeams["info"],
                 "potentialAction": MSTeams["link"]
             }
-    
+    # logger.info(json.dumps(message_data)) uncomment to debug
     # send message to webhook
-    http.request('POST', HOOK_URL,
+    response = http.request('POST', HOOK_URL,
                  headers={'Content-Type': 'application/json'},
                  body=json.dumps(message_data))
+    logger.info("Message: " + str(response.data))


### PR DESCRIPTION
Notifications were being rejected by Microsoft Teams for the following types of events:
- If provider was GitHub
- if Deployment provider was AWS Elastic Beanstalk

I have modified the json parsing logic to add support for the above two.